### PR TITLE
Add M3U8Player application link

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Applications with support of IPTV streams.
 
 - [Plex](https://www.plex.tv/apps-devices/#modal-devices-playstation-4) - Client-server media player. In order to watch IPTV through Plex App, you can use the [Cigaras/IPTV.bundle](https://github.com/Cigaras/IPTV.bundle) plugin.
 
-#### Online
+#### Web
 
 - [M3U8Player](https://m3u8player.netlify.app) - A minimal React player to play M3U8 URL online.
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Applications with support of IPTV streams.
 
 #### Online
 
-- [M3UPlayer](https://m3uplayer.netlify.app) - A minimal React player to play M3U8 URL online.
+- [M3U8Player](https://m3u8player.netlify.app) - A minimal React player to play M3U8 URL online.
 
 ## Providers
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Applications with support of IPTV streams.
 
 - [Plex](https://www.plex.tv/apps-devices/#modal-devices-playstation-4) - Client-server media player. In order to watch IPTV through Plex App, you can use the [Cigaras/IPTV.bundle](https://github.com/Cigaras/IPTV.bundle) plugin.
 
+#### Online
+
+- [M3UPlayer](https://m3uplayer.netlify.app) - A minimal React player to play M3U8 URL online.
+
 ## Providers
 
 List of IPTV providers.


### PR DESCRIPTION
- Add [M3U8Player](https://m3u8player.netlify.app/) application link
- Online application that has a minimal setup (a button that toggles form)
- No advertisements
- Easily accessible through URL, a free alternative instead of downloading third-party applications to test/watch a M3U URL
- Few limitations exist as React Player is not fully compatible with Mobile phones