### PR TITLE
English as default language for SS IPTV webpage

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Applications with support of IPTV streams.
 
 #### Smart TV
 
-- [SS IPTV](https://ss-iptv.com/) - Smart TV application which provided opportunity of IPTV viewing for its users.
+- [SS IPTV](https://ss-iptv.com/en) - Smart TV application which provided opportunity of IPTV viewing for its users.
 
 #### PlayStation
 


### PR DESCRIPTION
When accessing the server [https://ss-iptv.com/](https://ss-iptv.com/) it tries to redirect to language folder based on user settings/location. Sometimes that folder doesn't exist and it shows an empty page.

Example: [https://ss-iptv.com/es](https://ss-iptv.com/es)

Setting english as default language for SS IPTV webpage link ensures that content is displayed.