### PR TITLE
add Threadfin (an active xTeVe fork)

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Libraries and frameworks for working with IPTV data
 - [@iptv/playlist](https://www.npmjs.com/package/@iptv/playlist) - Fast M3U parser and generator for Node and browsers.
 - [weekend-project-space/web-tv](https://github.com/weekend-project-space/web-tv) - IPTV player with support for M3U playlists.
 - [xTeVe](https://github.com/xteve-project/xTeVe) - M3U Proxy for Plex DVR and Emby Live TV.
-- [Threadfin](https://github.com/Threadfin/Threadfin) - M3U proxy for Kernel/Plex/Jellyfin/Emby based on xTeVe
+- [Threadfin](https://github.com/Threadfin/Threadfin) - M3U proxy for Kernel/Plex/Jellyfin/Emby based on xTeVe.
 
 ## Contribution
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Libraries and frameworks for working with IPTV data
 - [@iptv/playlist](https://www.npmjs.com/package/@iptv/playlist) - Fast M3U parser and generator for Node and browsers.
 - [weekend-project-space/web-tv](https://github.com/weekend-project-space/web-tv) - IPTV player with support for M3U playlists.
 - [xTeVe](https://github.com/xteve-project/xTeVe) - M3U Proxy for Plex DVR and Emby Live TV.
+- [Threadfin](https://github.com/Threadfin/Threadfin) - M3U proxy for Kernel/Plex/Jellyfin/Emby based on xTeVe
 
 ## Contribution
 


### PR DESCRIPTION
xTeVe has a lot of errors that have been unfixed for a few years no sign of development. Threadfin has fixed some of them, uses a RAM buffer for streams, added a new UI, and some filtering and mapping features xTeVe doesn't have.