### PR TITLE
Add M3U Magic — Web-based M3U & M3U8 viewer and player

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Applications with support of IPTV streams.
 - [PublicIPTV](https://publiciptv.com/) - A free online IPTV stream player that lets you explore and watch live TV from around the world.
 - [SupercamBR](http://listas.supercambr.com.br/) - Free online iptv web player with channels from all over the world.
 - [Wizju IPTV Player](https://github.com/j2jstudio/wizju-iptv-player) - Lightweight, modern, browser‑based IPTV player built with Vue 3, Vite, TypeScript, Pinia, TailwindCSS and Video.js.
-- [M3U Magic](https://tools.cieloweb.com/tools/m3u-magic) – A fast, privacy-first web tool to open and play M3U and M3U8 playlists directly in your browser..
+- [M3U Magic](https://tools.cieloweb.com/tools/m3u-magic) – A fast, privacy-first web tool to open and play M3U and M3U8 playlists directly in your browser.
   
 #### Windows
 


### PR DESCRIPTION
This PR adds [M3U Magic](https://tools.cieloweb.com/tools/m3u-magic) under the Web Apps section.

M3U Magic is a fast, privacy-focused online tool to view, play, and analyze M3U and M3U8 IPTV playlists directly in the browser.  No server-side data storage, no account required, and fully client-side.