### PR TITLE
Add IPTV Checker GUI to Programming section

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Applications with support of IPTV streams.
 - [ynoTV](https://github.com/tbeezy/ynotv) - A feature-rich, open source IPTV player for Windows built on [Tauri v2](https://tauri.app/) and [mpv](https://mpv.io/).
 - [PlayOnTV](https://playontv.itch.io/playontv-windows) - Supports M3U, Xtream, and Stalker Portal with EPG, cloud sync, offline downloads, and watch progress tracking; free version without intrusive full-screen ads.
 - [Stream-Recorder](https://github.com/sc44/Stream-Recorder) - Flexible IPTV player and recorder with EPG.
+- [IPTV Checker](https://github.com/kristofferR/IPTVChecker) - Cross-platform IPTV player, playlist validator, and stream health checker with thumbnails and export.
 
 #### macOS
 
@@ -109,6 +110,7 @@ Applications with support of IPTV streams.
 - [QMPlay2](https://github.com/zaps166/QMPlay2) - A video and audio player which can play most formats and codecs.
 - [Streamlink](https://streamlink.github.io/index.html) - A command-line utility that extracts streams from various services and pipes them into a video player of choice.
 - [Jellyfin Desktop](https://github.com/jellyfin/jellyfin-desktop) - Free and open-source media server with built-in Live TV and IPTV support (M3U playlists and XMLTV EPG).
+- [IPTV Checker](https://github.com/kristofferR/IPTVChecker) - Cross-platform IPTV player, playlist validator, and stream health checker with thumbnails and export.
 
 #### Linux
 
@@ -132,6 +134,7 @@ Applications with support of IPTV streams.
 - [Better-IPTV](https://github.com/mewset/better-iptv) - Crossplatform IPTV player written in Rust and Typescript that handles extremely large playlists (150.000+ channels) without breaking a sweat.
 - [Jellyfin Desktop](https://flathub.org/en/apps/org.jellyfin.JellyfinDesktop) - Free and open-source media server with built-in Live TV and IPTV support (M3U playlists and XMLTV EPG).
 - [Stream-Recorder](https://github.com/sc44/Stream-Recorder) - Flexible IPTV player and recorder with EPG.
+- [IPTV Checker](https://github.com/kristofferR/IPTVChecker) - Cross-platform IPTV player, playlist validator, and stream health checker with thumbnails and export.
 
 #### Android
 


### PR DESCRIPTION
Adds [IPTV Checker GUI](https://github.com/kristofferR/IPTVChecker) — a cross-platform desktop app for validating IPTV playlists. Scans channels for health status, captures thumbnails via ffmpeg, and exports results. Built with Tauri v2, runs on macOS, Windows, and Linux.

Note: the CLI version ([IPTV Stream Checker](https://github.com/NewsGuyTor/IPTVChecker)) is already listed — this is a separate GUI application.