### PR TITLE
Add hls-restream-proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,7 @@ Libraries and frameworks for working with IPTV data
 - [weekend-project-space/web-tv](https://github.com/weekend-project-space/web-tv) - IPTV player with support for M3U playlists.
 - [xTeVe](https://github.com/xteve-project/xTeVe) - M3U Proxy for Plex DVR and Emby Live TV.
 - [Threadfin](https://github.com/Threadfin/Threadfin) - M3U proxy for Kernel/Plex/Jellyfin/Emby based on xTeVe.
+- [hls-restream-proxy](https://github.com/pcruz1905/hls-restream-proxy) - HLS reverse proxy that injects custom headers and rewrites m3u8 playlists for Jellyfin/Emby/Plex Live TV.
 - [IPTV Stream Checker](https://github.com/NewsGuyTor/IPTVChecker) - Command-line tool designed to check the status and capture screenshots of channels in an IPTV M3U8 playlist.
 - [flybird-downloader](https://github.com/youwen21/flybird-downloader) - M3U8 downloader and IPTV checker.
 - [davidclaeysquinones/epg-info-docker](https://github.com/davidclaeysquinones/epg-info-docker) - Docker container image for [iptv-org/epg](https://github.com/iptv-org/epg).

--- a/README.md
+++ b/README.md
@@ -376,12 +376,12 @@ Libraries and frameworks for working with IPTV data
 - [weekend-project-space/web-tv](https://github.com/weekend-project-space/web-tv) - IPTV player with support for M3U playlists.
 - [xTeVe](https://github.com/xteve-project/xTeVe) - M3U Proxy for Plex DVR and Emby Live TV.
 - [Threadfin](https://github.com/Threadfin/Threadfin) - M3U proxy for Kernel/Plex/Jellyfin/Emby based on xTeVe.
-- [hls-restream-proxy](https://github.com/pcruz1905/hls-restream-proxy) - HLS reverse proxy that injects custom headers and rewrites m3u8 playlists for Jellyfin/Emby/Plex Live TV.
 - [IPTV Stream Checker](https://github.com/NewsGuyTor/IPTVChecker) - Command-line tool designed to check the status and capture screenshots of channels in an IPTV M3U8 playlist.
 - [flybird-downloader](https://github.com/youwen21/flybird-downloader) - M3U8 downloader and IPTV checker.
 - [davidclaeysquinones/epg-info-docker](https://github.com/davidclaeysquinones/epg-info-docker) - Docker container image for [iptv-org/epg](https://github.com/iptv-org/epg).
 - [@iptv/xtream-api](https://www.npmjs.com/package/@iptv/xtream-api) - Work with Xtream compatible player API's in a standardized format.
 - [M3Unator](https://github.com/hasanbeder/M3Unator) - Transform any web directory into beautifully organized M3U/M3U8 playlists with smart media detection and recursive scanning capabilities.
+- [hls-restream-proxy](https://github.com/pcruz1905/hls-restream-proxy) - HLS reverse proxy that injects custom headers and rewrites m3u8 playlists for Jellyfin/Emby/Plex Live TV.
 
 ## Contribution
 


### PR DESCRIPTION
Added [hls-restream-proxy](https://github.com/pcruz1905/hls-restream-proxy) to the tools section alongside xTeVe and Threadfin.

HLS reverse proxy that injects custom HTTP headers (User-Agent, Referer) and rewrites m3u8 playlists so media servers like Jellyfin, Emby, and Plex can play streams that would otherwise return 403. Includes auto-detection of required headers and a refresh script for expiring tokens.

- Zero dependencies (Python 3.8+ stdlib only)
- Actively maintained
- MIT licensed