### PR TITLE
Add IPTVCloud to Players

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ Applications with support of IPTV streams.
 
 #### Web
 
-- [IPTVCloud.app](https://iptvcloudapp.vercel.app/) - An open-source, Next.js-powered IPTV player in beta that features adaptive bitrate streaming, cloud-synced favorites, and an integrated EPG, alongside unique community engagement tools and custom channel creation.
 - [IPTVnator](https://iptvnator.vercel.app/) - Open-source and cross-platform IPTV player application with multiple features, such as support of m3u and m3u8 playlists, favorites, TV archive/catchup and more.
 - [VidGrid](https://vidgrid.tk.gg) - News channel focused multiviewer with support for live m3u8 playlists, YouTube and Twitch streams with one-click audio switching.
 - [IPTV Smarter Player](http://webtv.iptvsmarters.com) - Video streaming player that allows your IPTV customers or end-users to stream content like Live TV, VOD, Series, and TV Catchup supplied by you.
@@ -63,6 +62,7 @@ Applications with support of IPTV streams.
 - [IPTV Link Search](http://tonkiang.us/) - Search for public IPTV channels.
 - [Jellyfin](https://demo.jellyfin.org/) - Free and open-source media server with built-in Live TV and IPTV support (M3U playlists and XMLTV EPG).
 - [StreamVault](https://streamvault.hopto.org/) - Browser-based IPTV client supporting Xtream Codes, Stalker Portal (MAC auth), and M3U with favorites, watch history, EPG guide, and multi-connection switching. ([Source Code](https://github.com/cowpooo-source/StreamVault))
+- [IPTVCloud.app](https://iptvcloudapp.vercel.app/) - An open-source, Next.js-powered IPTV player in beta that features adaptive bitrate streaming, cloud-synced favorites, and an integrated EPG, alongside unique community engagement tools and custom channel creation.
 
 #### Windows
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Applications with support of IPTV streams.
 
 #### Web
 
+- [IPTVCloud.app](https://iptvcloudapp.vercel.app/) - An open-source, Next.js-powered IPTV player in beta that features adaptive bitrate streaming, cloud-synced favorites, and an integrated EPG, alongside unique community engagement tools and custom channel creation.
 - [IPTVnator](https://iptvnator.vercel.app/) - Open-source and cross-platform IPTV player application with multiple features, such as support of m3u and m3u8 playlists, favorites, TV archive/catchup and more.
 - [VidGrid](https://vidgrid.tk.gg) - News channel focused multiviewer with support for live m3u8 playlists, YouTube and Twitch streams with one-click audio switching.
 - [IPTV Smarter Player](http://webtv.iptvsmarters.com) - Video streaming player that allows your IPTV customers or end-users to stream content like Live TV, VOD, Series, and TV Catchup supplied by you.


### PR DESCRIPTION
### Description

This PR adds **IPTVCloud.app** to the list of IPTV players. 

IPTVCloud.app is an open-source, Next.js-powered IPTV player currently in beta. It is designed to provide a modern, seamless viewing experience directly from the web.

**Key Features:**
* Adaptive bitrate streaming
* Channel lists, and live chat for engagement.
* Account system for syncing history, and posting.
* Cloud-synced favorites.
* Integrated EPG (Electronic Program Guide).
* Community engagement tools and custom channel creation.

**Links:**
* **Repository:** https://github.com/ReinfyTeam/IPTVCloud.app
* **Live Demo:** https://iptvcloudapp.vercel.app/home

**Note for Maintainers:**
The project is currently in its free open-beta phase, and we are actively looking for beta testers and open-source contributors! As a thank-you to the iptv-org community, any of your collaborators or maintainers who join will gladly be granted a verified account badge on our platform.

*(Note: The live demo URL may migrate to a custom domain upon official release, but the GitHub repository link will remain permanent).*