### PR TITLE
Add Nova Core (DVB-to-IP streaming headend) to Programming

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ Libraries and frameworks for working with IPTV data
 - [M3Unator](https://github.com/hasanbeder/M3Unator) - Transform any web directory into beautifully organized M3U/M3U8 playlists with smart media detection and recursive scanning capabilities.
 - [hls-restream-proxy](https://github.com/pcruz1905/hls-restream-proxy) - HLS reverse proxy that injects custom headers and rewrites m3u8 playlists for Jellyfin/Emby/Plex Live TV.
 - [HLS Proxy Worker](https://github.com/MHSanaei/HLS-Proxy-Worker) - A Cloudflare Worker that helps you fetch and rewrite HLS (.m3u8) playlists.
+- [Nova Core](https://github.com/novaheadend/nova-core-releases) - Single-binary DVB-S/S2/T/T2/C to IP streaming headend (HTTP-TS, UDP, M3U) with a web UI and EPG.
 
 ## Contribution
 


### PR DESCRIPTION
Adds **Nova Core** to the Programming section — a self-hosted DVB-S/S2/T/T2/C to IP streaming headend (HTTP-TS / UDP / M3U output, web UI, EPG).

It fits alongside the existing server-side tools in this section (xTeVe, Threadfin): rather than a player, it turns DVB tuner hardware into IP streams. Single static binary (no ffmpeg/deps), Linux amd64/arm64/armv7.

Repo: https://github.com/novaheadend/nova-core-releases