### PR TITLE
Add XPlayer (Android & Android TV)

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Applications with support of IPTV streams.
 - [GoldenView IPTV](https://play.google.com/store/apps/details?id=com.primutech.iptvplayer) - Gives you instant access to over 8,500 live TV channels from around the world completely free.
 - [Smart Player](https://play.google.com/store/apps/details?id=com.mehmedmert.mediaplayer.mobile) - Allows you to manage your media, videos, streams, IP tv etc. in an easy and smart way in one place.
 - [StreamVault IPTV](https://github.com/Davidona/StreamVault-IPTV) – Feature-rich, completely free IPTV player for Android with M3U, Xtream, and Stalker support, EPG, DVR, timeshift, multi-view, and optimized large-playlist performance.
+- [XPlayer](https://github.com/TNT-Likely/xplayer) - Free and open-source cross-platform IPTV/M3U player with channel grouping, search, EPG, favorites, and a companion phone app for remote text input on TV.
 
 #### iPhone
 
@@ -267,6 +268,7 @@ Applications with support of IPTV streams.
 - [StreamVault IPTV](https://github.com/Davidona/StreamVault-IPTV) – Feature-rich, completely free IPTV player for Android TV with M3U, Xtream, and Stalker support, EPG, DVR, timeshift, multi-view, and optimized large-playlist performance.
 - [Nightmare TV](https://github.com/zeze89/nightmare-tv-releases/releases/latest) - libmpv-based IPTV/M3U/Xtream Codes player for Android TV with HDR tone-mapping, Dolby Atmos/DTS-X passthrough, and multi-view.
 - [ScoreBox](https://play.google.com/store/apps/details?id=net.darkforeststudios.scorebox) - Sports focused IPTV player that finds the channels carrying each game across your providers, for the teams and leagues you follow.
+- [XPlayer](https://github.com/TNT-Likely/xplayer) - Free and open-source IPTV/M3U player for Android TV with channel grouping, search, EPG, and a companion phone app for remote text input over the LAN.
 
 #### WebOS
 


### PR DESCRIPTION
Adds **XPlayer** — a free & open-source, cross-platform IPTV/M3U player — to the **Android** and **Android TV** sections.

- Source code: https://github.com/TNT-Likely/xplayer
- Platforms: Android, Android TV, iOS, macOS, Windows, Linux (Flutter)
- Features: built-in iptv-org playlists, channel grouping & search, EPG, favorites, and a companion phone app for remote text input on TV (handy for typing on Android TV).

Follows the contribution rules — one-sentence description, appended to the end of each section, the app name is not repeated in the description, and the link points to the open-source repo.