### PR TITLE
Add Klipa (Android, Android TV)

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Applications with support of IPTV streams.
 - [GoldenView IPTV](https://play.google.com/store/apps/details?id=com.primutech.iptvplayer) - Gives you instant access to over 8,500 live TV channels from around the world completely free.
 - [Smart Player](https://play.google.com/store/apps/details?id=com.mehmedmert.mediaplayer.mobile) - Allows you to manage your media, videos, streams, IP tv etc. in an easy and smart way in one place.
 - [StreamVault IPTV](https://github.com/Davidona/StreamVault-IPTV) – Feature-rich, completely free IPTV player for Android with M3U, Xtream, and Stalker support, EPG, DVR, timeshift, multi-view, and optimized large-playlist performance.
+- [Klipa](https://play.google.com/store/apps/details?id=klipa.tv) - Free player for local M3U playlists and Xtream Codes logins with EPG, favorites, VOD and series, no ads or account.
 
 #### iPhone
 
@@ -270,6 +271,7 @@ Applications with support of IPTV streams.
 - [StreamVault IPTV](https://github.com/Davidona/StreamVault-IPTV) – Feature-rich, completely free IPTV player for Android TV with M3U, Xtream, and Stalker support, EPG, DVR, timeshift, multi-view, and optimized large-playlist performance.
 - [Nightmare TV](https://github.com/zeze89/nightmare-tv-releases/releases/latest) - libmpv-based IPTV/M3U/Xtream Codes player for Android TV with HDR tone-mapping, Dolby Atmos/DTS-X passthrough, and multi-view.
 - [ScoreBox](https://play.google.com/store/apps/details?id=net.darkforeststudios.scorebox) - Sports focused IPTV player that finds the channels carrying each game across your providers, for the teams and leagues you follow.
+- [Klipa](https://play.google.com/store/apps/details?id=klipa.tv) - Free M3U and Xtream Codes player with EPG and a remote-friendly layout, no ads or account.
 
 #### WebOS
 


### PR DESCRIPTION
Adds Klipa to the Android and Android TV app lists.

Klipa is a free IPTV player for local M3U playlists and Xtream Codes logins, with EPG, favorites, VOD and series. No ads, no account, no subscription. It runs on Android phones and Android TV.

Play Store: https://play.google.com/store/apps/details?id=klipa.tv
Site: https://klipa.tv

Both entries are appended to the end of their sections and link to the Play Store, following the contribution rules.
