### PR TITLE
Add Nightmare TV to macOS section

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Applications with support of IPTV streams.
 - [sbtlTV](https://github.com/thesubtleties/sbtlTV) - A free, open-source desktop IPTV player built with Electron and mpv, focused on a simple, low-latency experience with Xtream and M3U support, EPG, movies and series, multi-source merging, and watch progress.
 - [ShallowTV](https://apps.apple.com/us/app/shallowtv/id6757123182?platform=mac) - Free IPTV player with M3U playlist support for Mac, iPhone, iPad, Apple TV and Apple Vision Pro.
 - [Streamline](https://apps.apple.com/us/app/streamline-iptv-m3u-editor/id6760606054?platform=mac) - Free M3U and IPTV playlist editor with duplicate detection, ffmpeg-based playback and a built-in HTTP server for managing playlists.
+- [Nightmare TV](https://github.com/zeze89/nightmare-tv-releases/releases/latest) - libmpv-based IPTV/M3U/Xtream Codes player for macOS (beta) with HDR tone-mapping (BT.2390), 4K HEVC/AV1 hardware decode, and multi-view.
 
 #### Linux
 


### PR DESCRIPTION
Adds Nightmare TV to the macOS list. It's already listed under **Windows** and **Android TV** in this README; the macOS build (Apple Silicon + Intel, currently beta) now ships, so this adds the matching macOS entry.

It's a player-only app — bring your own M3U/Xtream playlist, no content hosted — built on libmpv. Disclosure: I maintain it.

Accuracy note vs. the Windows/Android TV entries: the macOS line intentionally **omits Atmos/DTS-X passthrough**, because on macOS audio is multichannel PCM, not bitstream — kept the description honest.