### PR TITLE
add IPTVCat link to providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ Applications with support of IPTV streams.
 - [EBK IPTV](https://ebkiptv.live/) - Watch online with pre-defined lists, share custom lists, add custom URLs, channel/country search, and PWA support.
 - [Free-TV IPTV](https://freetv.mokdo.click/) - More than 8,000 worldwide channels sorted by country.
 - [TV Explorer](https://tvexplorer.live) - Browser-based player with a live, self-updating playlist of 10,000 free-to-air channels from 177 countries with category, country, and language filtering, and multiview, casting, screenshots, and sharing with no account required.
+- [IPTVCat](https://iptvcat.com) - A scraper with more than 20,000 channels which scrapes stream links from different websites and automatically checks their health
 
 ## Channel Datasets
 

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ Applications with support of IPTV streams.
 - [EBK IPTV](https://ebkiptv.live/) - Watch online with pre-defined lists, share custom lists, add custom URLs, channel/country search, and PWA support.
 - [Free-TV IPTV](https://freetv.mokdo.click/) - More than 8,000 worldwide channels sorted by country.
 - [TV Explorer](https://tvexplorer.live) - Browser-based player with a live, self-updating playlist of 10,000 free-to-air channels from 177 countries with category, country, and language filtering, and multiview, casting, screenshots, and sharing with no account required.
-- [IPTVCat](https://iptvcat.com) - A scraper with more than 20,000 channels which scrapes stream links from different websites and automatically checks their health
+- [IPTVCat](https://iptvcat.com) - A scraper with more than 20,000 channels which scrapes stream links from different websites and automatically checks their health.
 
 ## Channel Datasets
 


### PR DESCRIPTION
This PR adds a website called IPTVCat under the Providers section.

IPTVCat is a scraper which scrapes streams from various websites and checks for their health (online/offline)

Disclaimer: This PR is just a contribution from me to the Awesome IPTV community with links that I found publicly on the internet and have existed for a long time. I don't own any of the links in the commits here so please don't message me privately about them (I had to add the note because some people actually message me about my PRs on here)