### PR TITLE
Update README.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_link.yml
+++ b/.github/ISSUE_TEMPLATE/new_link.yml
@@ -6,7 +6,7 @@ body:
     id: link
     attributes:
       label: Link
-      description: For Android, iPhone, iPad, Apple Watch, Apple TV, Apple Vision Pro, Android TV, WebOS, Roku, Xbox and Google Chrome apps link should lead to a reputable app store or source code
+      placeholder: 'https://example.com'
     validations:
       required: true
   - type: textarea

--- a/README.md
+++ b/README.md
@@ -44,7 +44,14 @@ A curated list of resources related to IPTV.
 
 ## Contribution
 
-To add a new link to the list, simply fill out this [form](https://github.com/iptv-org/awesome-iptv/issues/new?template=new_link.yml). Once reviewed, it will be published in the appropriate category in the [Discussions](https://github.com/iptv-org/awesome-iptv/discussions) tab.
+To add a new link to the list, simply fill out this [form](https://github.com/iptv-org/awesome-iptv/issues/new?template=new_link.yml). 
+
+Just please follow two simple rules:
+
+- the title should only contain the name of the app or service
+- the link should not lead to a file download
+
+Once reviewed, the link will be published in the appropriate category in the [Discussions](https://github.com/iptv-org/awesome-iptv/discussions) tab.
 
 ## License
 


### PR DESCRIPTION
Changes:

- two new rules have been added to the "Contribution" section

  > - the title should only contain the name of the app or service
  > - the link should not lead to a file download

- the description for the "Link" field was removed from the form
  
  > ~For Android, iPhone, iPad, Apple Watch, Apple TV, Apple Vision Pro, Android TV, WebOS, Roku, Xbox and Google Chrome apps link should lead to a reputable app store or source code~
  
  Since a link can now lead to a landing page with multiple versions of the app, this rule no longer applicable.